### PR TITLE
add: pygame GUI of note editor

### DIFF
--- a/Grid.py
+++ b/Grid.py
@@ -1,0 +1,109 @@
+import pygame
+
+def sortKey(dict):
+    return dict["StartTime"]
+
+class CLS_Grid(object):
+    def __init__(self, content):
+        self.content = content
+        self.content["NoteList"].sort(key = sortKey)
+        pygame.init()
+        self.screen = pygame.display.set_mode([770, 950])
+        self.screen.fill([255, 255, 255])
+        self.side = 110 #self.side length of a square
+
+    def drawTimeNum(self, start):
+        font = pygame.font.Font(None, 50)
+        for i in range(start, start + 8):
+            surf = font.render(str(i), 1, [0, 0, 0])
+            self.screen.blit(surf, [self.side * 6 + 10, self.side * (start + 8 - i) - 15])
+
+    def clean(self):
+        self.screen.fill([255, 255, 255])
+        for x in range(1, 6):
+            for y in range(1, 8):
+                square = [x*self.side, y*self.side, self.side, self.side]
+                pygame.draw.rect(self.screen, [0, 0, 0], square, 2)
+
+        #draw a big rect to make the line width outside the same
+        pygame.draw.rect(
+            self.screen, 
+            [0, 0, 0],
+            [self.side, self.side, self.side * 5, self.side * 7], 
+            4
+            )
+
+    def draw(self):
+        for dict in self.content["NoteList"]:
+            self.drawImpl(
+                dict["Type"], 
+                dict["Rail"], 
+                int(dict["StartTime"]) - int(dict["DelayTime"]), 
+                int(dict["StartTime"]), 
+                int(dict["Length"]) + int(dict["StartTime"])
+                )
+        pygame.display.flip()
+
+
+    def paint(self, start, notes):
+        self.clean()
+        self.drawTimeNum(start)
+        for dict in notes:
+            if int(dict["StartTime"]) >= start or \
+                (int(dict["Length"]) + int(dict["StartTime"])) <= start + 7 or \
+                (int(dict["StartTime"]) < start and int(dict["Length"]) > 7):
+                self.drawImpl(
+                    dict["Type"], 
+                    dict["Rail"], 
+                    int(dict["StartTime"]) - int(dict["DelayTime"]) - start, 
+                    int(dict["StartTime"]) - start, 
+                    int(dict["Length"]) + int(dict["StartTime"]) - start
+                    )
+        pygame.display.flip()
+
+    # "Type" = noteType
+    # "Rail" = lane
+    # int("StartTime") - int("DelayTime") = appearTime 
+    # int("StartTime") = touchLineTime
+    # int("Length") + int("StartTime") = allThroughLineTime
+    def drawImpl(self, noteType, lane, appearTime, touchLineTime, allThroughLineTime): 
+        color = {'flick' : [237, 28, 36], 'hold' : [255, 174, 201], 'avoid' : [181, 230, 29]}
+        length = {
+            'flick' : 10, 
+            'hold' : (allThroughLineTime - touchLineTime) * self.side, 
+            'avoid' : (allThroughLineTime - touchLineTime) * self.side
+            }
+        adj ={'flick' : -5, 'hold' : 0, 'avoid' : 0}
+        pygame.draw.rect(
+            self.screen, 
+            color[noteType], 
+            [
+                (lane + 3) * self.side, 
+                (8 - allThroughLineTime) * self.side + adj[noteType], 
+                self.side, 
+                length[noteType]
+            ], 
+            0
+            )
+        pygame.draw.rect(
+            self.screen, 
+            [195, 195, 195], 
+            [
+                (lane + 3) * self.side + 0.5 * self.side - 5, 
+                (8 - touchLineTime) * self.side - adj[noteType], 
+                10, 
+                (touchLineTime - appearTime) * self.side + adj[noteType]
+            ], 
+            0
+            )
+        pygame.draw.rect(
+            self.screen, 
+            [195, 195, 195], 
+            [
+                (lane + 3) * self.side + 10, 
+                (8 - appearTime) * self.side - 6, 
+                self.side - 20, 
+                6
+            ], 
+            0
+            )

--- a/Music.py
+++ b/Music.py
@@ -1,0 +1,19 @@
+import pygame
+
+class CLS_Music(object):
+
+    def __init__(self, path):
+        pygame.mixer.init()
+        #pygame.time.delay(1000)
+        pygame.mixer.music.load(path)
+    
+    def play(self):
+        pygame.mixer.music.play()
+
+    def toggle(self):
+        self.playing = pygame.mixer.music.get_busy()
+        if self.playing:
+            pygame.mixer.music.pause()
+        else:
+            pygame.mixer.music.unpause()
+

--- a/NoteEditor.py
+++ b/NoteEditor.py
@@ -1,0 +1,56 @@
+import pygame, sys
+from jsonIO import CLS_JsonReader, CLS_JsonSaver
+from Music import CLS_Music
+from Grid import CLS_Grid
+
+#bound = "l" or "r"
+def binarySearch(list, target, bound):
+    left = 0
+    right = len(list)
+    while(left < right):
+        mid = int(left + (right - left) / 2)
+        if list[mid] < target:
+            left = mid + 1
+        elif list[mid] > target:
+            right = mid
+        else:
+            if bound == "l":
+                right = mid
+            else:
+                left = mid + 1
+    if bound == "l":
+        return left
+    else: 
+        return left - 1
+
+
+if __name__ == '__main__':
+    metapath = "C:\wjy\code\PYTHON\MUNECK_editor\chart5.json"
+    loader = CLS_JsonReader(metapath)
+    content = loader.get_content()
+
+    grid = CLS_Grid(content)
+    grid.clean()
+
+    music = CLS_Music("C:\wjy\music\Kankitsu - Chronomia.mp3")
+    music.play()
+
+    while 1:
+        for event in pygame.event.get():
+            if event.type == pygame.QUIT:
+                sys.exit()
+            if event.type == pygame.KEYDOWN:
+                if event.key == pygame.K_SPACE:
+                    music.toggle()
+                # elif event.key == pygame.K_LEFT:
+                #     pygame.mixer.music.set_pos(7)
+                #     #music.play()
+                # elif event.key == pygame.K_RIGHT:
+                #     pygame.mixer.music.set_pos(20)
+                #     #music.play()
+        grid.paint(int(pygame.mixer.music.get_pos() / 1000), content["NoteList"])
+        pygame.time.delay(1000)
+
+                
+            
+            


### PR DESCRIPTION
added the pygame GUI and two classes, CLS_Grid and CLS_Music

- pygame GUI : 

>  now you can just load the chart in and it will display it on the GUI (the grid) and it will play at a speed of 1 refreshment per 
>  second. The music is able to pause when space is pressed

- CLS_Grid : draw() and paint()

>  __init__ : receives the chart (json)

>  draw() : draw the static grid (useless now, might be deleted)

>  paint() : paint the current grid according to the given parameter (which is the time **in seconds**)

- CLS_Music : play() and toggle()

>  __init__ : receives the music

>  play() : play the music

>  toggle() : able to pause and unpause the music

todo:

1. fps
2. change the grid's unit
3. use the chart-related classes
4. add feature so the chart can jump for/backwards if pressed left/right keys

ps : 
![6f207c0060d64fe8e27088f40328eed](https://user-images.githubusercontent.com/105262796/169656928-a06e4440-beb9-4c17-843f-d392dff27119.jpg)
1 is the time it appears
2 is the time it touches the receiver
3 is the time when the whole note passes through the receiver (esp. for hold and avoid)
(2 = 3 if it is flick)

